### PR TITLE
Fix Vulkan SDK path detection and tilde path normalization on windows

### DIFF
--- a/crates/skill-settings/src/lib.rs
+++ b/crates/skill-settings/src/lib.rs
@@ -451,7 +451,7 @@ pub fn tilde_path(p: &Path) -> String {
         }
         if let Some(rest) = s.strip_prefix(h) {
             if rest.starts_with('/') || rest.starts_with('\\') {
-                return format!("~{rest}");
+                return format!("~{}", rest.replace('\\', "/"));
             }
         }
     }

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -819,10 +819,11 @@ fn clear_readonly(path: &Path) {
 fn setup_vulkan_sdk_windows() {
     // use std::fs;
 
-    let vulkan_sdk_path = "C:\\VulkanSDK";
+    let vulkan_sdk_path =
+        std::env::var("VULKAN_SDK").unwrap_or_else(|_| "C:\\VulkanSDK".to_string());
 
     // Check if Vulkan SDK is already installed
-    if Path::new(vulkan_sdk_path).exists() {
+    if Path::new(&vulkan_sdk_path).exists() {
         println!(
             "cargo:warning=Vulkan SDK already installed at {}",
             vulkan_sdk_path


### PR DESCRIPTION
**Description:**
This PR contains two main optimizations:

1. `setup_vulkan_sdk_windows `now reads the `VULKAN_SDK ` environment variable (set by the SDK installer) before falling back to the hardcoded `C:\VulkanSDK` — prevents unnecessary reinstalls when the SDK is installed to a non-default location.

2. `tilde_path `now normalizes backslashes to forward slashes in its output on Windows, so it consistently returns ~/... across all platforms — fixes the tilde_path_contracts_home pre-push hook test failure on Windows. This comes up when the `pre-push` hook is ran.

**Details**

**Vulkan SDK path detection**: the SDK installer sets the `VULKAN_SDK `env var to its install location. Previously this was ignored, meaning machines with the SDK installed outside `C:\VulkanSDK` (like in my case) would always trigger a reinstall during the build. The build script now respects that env var and falls back to `C:\VulkanSDK` only when it is unset.

**`tilde_path `normalization**: on Windows,` Path::join` produces backslash-separated paths, causing `tilde_path `to return `~.skill\settings.json` instead of the expected `~/.skill/settings.json`. The fix replaces backslashes with forward slashes in the tilde-prefixed output only. The fallback branch (non-home paths) is untouched, and on Mac/Linux the replace call is a no-op so existing behavior is fully preserved. This comes up when you try to make a push from a windows machine. In my case Windows 11.

See failing test screenshot below:
<img width="394" height="315" alt="Screenshot 2026-03-30 005639" src="https://github.com/user-attachments/assets/f5e08ade-4f5f-45e0-a98b-0bb3437245a6" />

