### PR TITLE
ci: speed up llama builds with prebuilt artifacts + safe fallback

### DIFF
--- a/.github/actions/setup-rust-bootstrap-linux/action.yml
+++ b/.github/actions/setup-rust-bootstrap-linux/action.yml
@@ -27,3 +27,12 @@ runs:
     - name: Setup sccache
       if: inputs.use-sccache == 'true'
       uses: Mozilla-Actions/sccache-action@v0.0.9
+
+    - name: Configure sccache (GitHub Actions backend)
+      if: inputs.use-sccache == 'true'
+      shell: bash
+      run: |
+        echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+        echo "SCCACHE_CACHE_SIZE=10G" >> "$GITHUB_ENV"
+        # Bump to invalidate all remote sccache entries after major toolchain changes.
+        echo "SCCACHE_GHA_VERSION=1" >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
         uses: Swatinem/rust-cache@v2.9.0
         with:
           workspaces: ". -> src-tauri/target"
+          shared-key: linux-ci-x86_64-unknown-linux-gnu-v1
           cache-targets: false
           cache-on-failure: false
 
@@ -111,16 +112,74 @@ jobs:
       - name: Setup Vulkan SDK
         uses: ./.github/actions/setup-vulkan-linux
 
+      - name: Download prebuilt llama libs (Linux, optional)
+        shell: bash
+        run: |
+          set -euo pipefail
+          URL="https://github.com/eugenehp/llama-cpp-rs/releases/latest/download/llama-prebuilt-linux-x86_64-unknown-linux-gnu-q1-vulkan.tar.gz"
+          ARCHIVE="$RUNNER_TEMP/llama-prebuilt-linux.tar.gz"
+          DEST="$RUNNER_TEMP/llama-prebuilt-linux"
+          EXPECTED_TARGET="x86_64-unknown-linux-gnu"
+          EXPECTED_FEATURE="vulkan"
+          mkdir -p "$DEST"
+
+          if ! curl -fL "$URL" -o "$ARCHIVE"; then
+            echo "[warn] prebuilt llama artifact unavailable; fallback to source build"
+            exit 0
+          fi
+
+          tar -xzf "$ARCHIVE" -C "$DEST"
+          ROOT="$DEST"
+          if [[ ! -d "$ROOT/lib" && ! -d "$ROOT/lib64" && ! -d "$ROOT/bin" ]]; then
+            ROOT="$(find "$DEST" -mindepth 1 -maxdepth 1 -type d | head -n1 || true)"
+          fi
+
+          if [[ -z "${ROOT:-}" ]]; then
+            echo "[warn] prebuilt llama archive layout invalid; fallback to source build"
+            exit 0
+          fi
+
+          if ! find "$ROOT" -type f \( -name '*.a' -o -name '*.so' \) | head -n1 >/dev/null; then
+            echo "[warn] prebuilt llama archive contains no static/shared libs; fallback to source build"
+            exit 0
+          fi
+
+          if [[ -f "$ROOT/metadata.json" ]]; then
+            TARGET="$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1])).get("target",""))' "$ROOT/metadata.json")"
+            FEATURES="$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1])).get("features",""))' "$ROOT/metadata.json")"
+            if [[ "$TARGET" != "$EXPECTED_TARGET" || "$FEATURES" != *"$EXPECTED_FEATURE"* ]]; then
+              echo "[warn] prebuilt metadata mismatch (target=$TARGET features=$FEATURES); fallback to source build"
+              exit 0
+            fi
+          fi
+
+          echo "LLAMA_PREBUILT_DIR=$ROOT" >> "$GITHUB_ENV"
+          echo "LLAMA_PREBUILT_SHARED=0" >> "$GITHUB_ENV"
+          echo "[ok] LLAMA_PREBUILT_DIR=$ROOT"
+
       # clippy (workspace crates — no espeak/Vulkan deps needed)
       - name: cargo clippy (workspace crates)
         env:
           RUSTC_WRAPPER: sccache
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: -C link-arg=-fuse-ld=mold
-        run: >
-          cargo clippy --locked --target x86_64-unknown-linux-gnu
-          --workspace --exclude skill
-          -- -D warnings
+        shell: bash
+        run: |
+          set -euo pipefail
+          run_cmd() {
+            cargo clippy --locked --target x86_64-unknown-linux-gnu \
+              --workspace --exclude skill \
+              -- -D warnings
+          }
+          if ! run_cmd; then
+            if [[ -n "${LLAMA_PREBUILT_DIR:-}" ]]; then
+              echo "::warning::clippy failed with prebuilt llama; retrying with source build"
+              unset LLAMA_PREBUILT_DIR LLAMA_PREBUILT_SHARED
+              run_cmd
+            else
+              exit 1
+            fi
+          fi
 
       # clippy (app crate — needs espeak + Vulkan)
       - name: cargo clippy (app)
@@ -131,7 +190,21 @@ jobs:
           # Cache cmake-based -sys crate builds (llama-cpp-sys, etc.)
           CMAKE_C_COMPILER_LAUNCHER:   sccache
           CMAKE_CXX_COMPILER_LAUNCHER: sccache
-        run: cargo clippy -p skill --locked --target x86_64-unknown-linux-gnu --features llm-vulkan,screenshots -- -D warnings
+        shell: bash
+        run: |
+          set -euo pipefail
+          run_cmd() {
+            cargo clippy -p skill --locked --target x86_64-unknown-linux-gnu --features llm-vulkan,screenshots -- -D warnings
+          }
+          if ! run_cmd; then
+            if [[ -n "${LLAMA_PREBUILT_DIR:-}" ]]; then
+              echo "::warning::app clippy failed with prebuilt llama; retrying with source build"
+              unset LLAMA_PREBUILT_DIR LLAMA_PREBUILT_SHARED
+              run_cmd
+            else
+              exit 1
+            fi
+          fi
 
       # Determine which crates need testing based on changed files.
       # On PRs: compare against the base branch.
@@ -201,9 +274,20 @@ jobs:
         run: |
           set -euo pipefail
           start_ts="$(date +%s)"
-          cargo test --locked --target x86_64-unknown-linux-gnu \
-            ${{ steps.changed.outputs.crate_flags }} \
-            --lib
+          run_cmd() {
+            cargo test --locked --target x86_64-unknown-linux-gnu \
+              ${{ steps.changed.outputs.crate_flags }} \
+              --lib
+          }
+          if ! run_cmd; then
+            if [[ -n "${LLAMA_PREBUILT_DIR:-}" ]]; then
+              echo "::warning::unit tests failed with prebuilt llama; retrying with source build"
+              unset LLAMA_PREBUILT_DIR LLAMA_PREBUILT_SHARED
+              run_cmd
+            else
+              exit 1
+            fi
+          fi
           end_ts="$(date +%s)"
           echo "duration_sec=$((end_ts - start_ts))" >> "$GITHUB_OUTPUT"
 
@@ -218,9 +302,20 @@ jobs:
         run: |
           set -euo pipefail
           start_ts="$(date +%s)"
-          cargo test --locked --target x86_64-unknown-linux-gnu \
-            ${{ steps.changed.outputs.int_flags }} \
-            --test '*'
+          run_cmd() {
+            cargo test --locked --target x86_64-unknown-linux-gnu \
+              ${{ steps.changed.outputs.int_flags }} \
+              --test '*'
+          }
+          if ! run_cmd; then
+            if [[ -n "${LLAMA_PREBUILT_DIR:-}" ]]; then
+              echo "::warning::integration tests failed with prebuilt llama; retrying with source build"
+              unset LLAMA_PREBUILT_DIR LLAMA_PREBUILT_SHARED
+              run_cmd
+            else
+              exit 1
+            fi
+          fi
           end_ts="$(date +%s)"
           echo "duration_sec=$((end_ts - start_ts))" >> "$GITHUB_OUTPUT"
 
@@ -253,6 +348,25 @@ jobs:
         run: |
           mkdir -p ci-metrics
           sccache --show-stats > ci-metrics/rust-sccache-stats.txt || true
+
+      - name: Summarize sccache hit rate (Rust job)
+        if: always()
+        shell: bash
+        run: |
+          STATS=ci-metrics/rust-sccache-stats.txt
+          if [[ ! -f "$STATS" ]]; then
+            echo "- sccache stats: unavailable" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          TOTAL_HIT_RATE="$(awk '/^Cache hits rate[[:space:]]/{print $(NF-1)" "$NF; exit}' "$STATS")"
+          RUST_HIT_RATE="$(awk '/^Cache hits rate \(Rust\)/{print $(NF-1)" "$NF; exit}' "$STATS")"
+          CACHE_LOCATION="$(awk -F'Cache location[[:space:]]+' '/^Cache location/{print $2; exit}' "$STATS")"
+          {
+            echo "## sccache metrics (Rust job)"
+            echo "- Cache location: ${CACHE_LOCATION:-unknown}"
+            echo "- Total hit rate: ${TOTAL_HIT_RATE:-unknown}"
+            echo "- Rust hit rate: ${RUST_HIT_RATE:-unknown}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload Rust health metrics
         if: always()
@@ -430,6 +544,7 @@ jobs:
         uses: Swatinem/rust-cache@v2.9.0
         with:
           workspaces: ". -> src-tauri/target"
+          shared-key: windows-ci-x86_64-pc-windows-msvc-v1
           cache-targets: false
           cache-on-failure: false
 
@@ -441,6 +556,33 @@ jobs:
       # ── Build cache (sccache) ───────────────────────────────────────────────
       - name: Setup sccache
         uses: Mozilla-Actions/sccache-action@v0.0.9
+
+      - name: Configure sccache for GitHub Actions cache
+        shell: bash
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+          echo "SCCACHE_CACHE_SIZE=10G" >> "$GITHUB_ENV"
+          echo "SCCACHE_GHA_VERSION=1" >> "$GITHUB_ENV"
+
+          # Ensure cargo.exe can always resolve sccache on Windows.
+          if [ -n "${SCCACHE_PATH:-}" ]; then
+            SCCACHE_DIR="$(dirname "$SCCACHE_PATH")"
+            if [ -f "$SCCACHE_DIR/sccache.exe" ]; then
+              SCCACHE_NATIVE="$(cygpath -w "$SCCACHE_DIR/sccache.exe")"
+              echo "RUSTC_WRAPPER=$SCCACHE_NATIVE" >> "$GITHUB_ENV"
+              echo "$SCCACHE_DIR" >> "$GITHUB_PATH"
+              echo "[ok] RUSTC_WRAPPER=$SCCACHE_NATIVE"
+            elif [ -f "$SCCACHE_PATH.exe" ]; then
+              SCCACHE_NATIVE="$(cygpath -w "$SCCACHE_PATH.exe")"
+              echo "RUSTC_WRAPPER=$SCCACHE_NATIVE" >> "$GITHUB_ENV"
+              echo "$(dirname "$SCCACHE_PATH.exe")" >> "$GITHUB_PATH"
+              echo "[ok] RUSTC_WRAPPER=$SCCACHE_NATIVE"
+            else
+              echo "[warn] sccache binary not found via SCCACHE_PATH=$SCCACHE_PATH"
+            fi
+          else
+            echo "[warn] SCCACHE_PATH not set; relying on PATH resolution"
+          fi
 
       - name: Install protoc (Windows)
         shell: powershell
@@ -503,6 +645,53 @@ jobs:
           "VULKAN_SDK=$env:VULKAN_SDK" |
             Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           Write-Host "[ok] Exported VULKAN_SDK=$env:VULKAN_SDK"
+
+      - name: Download prebuilt llama libs (Windows, optional)
+        shell: powershell
+        run: |
+          $url = "https://github.com/eugenehp/llama-cpp-rs/releases/latest/download/llama-prebuilt-windows-x86_64-pc-windows-msvc-q1-vulkan.tar.gz"
+          $archive = Join-Path $env:RUNNER_TEMP "llama-prebuilt-windows.tar.gz"
+          $dest = Join-Path $env:RUNNER_TEMP "llama-prebuilt-windows"
+          $expectedTarget = "x86_64-pc-windows-msvc"
+          $expectedFeature = "vulkan"
+          New-Item -ItemType Directory -Force -Path $dest | Out-Null
+
+          try {
+            Invoke-WebRequest -Uri $url -OutFile $archive
+            tar -xzf $archive -C $dest
+
+            $root = $dest
+            if (-not (Test-Path (Join-Path $root "lib")) -and -not (Test-Path (Join-Path $root "lib64")) -and -not (Test-Path (Join-Path $root "bin"))) {
+              $candidate = Get-ChildItem $dest -Directory | Select-Object -First 1
+              if ($candidate) { $root = $candidate.FullName }
+            }
+
+            if (-not $root -or -not (Test-Path $root)) {
+              Write-Host "[warn] prebuilt llama archive layout invalid; fallback to source build"
+              exit 0
+            }
+
+            $libs = Get-ChildItem -Path $root -Recurse -File -Include *.lib,*.dll -ErrorAction SilentlyContinue | Select-Object -First 1
+            if (-not $libs) {
+              Write-Host "[warn] prebuilt llama archive contains no windows libs; fallback to source build"
+              exit 0
+            }
+
+            $metadataPath = Join-Path $root "metadata.json"
+            if (Test-Path $metadataPath) {
+              $meta = Get-Content $metadataPath -Raw | ConvertFrom-Json
+              if ($meta.target -ne $expectedTarget -or -not ($meta.features -like "*$expectedFeature*")) {
+                Write-Host "[warn] prebuilt metadata mismatch (target=$($meta.target) features=$($meta.features)); fallback to source build"
+                exit 0
+              }
+            }
+
+            "LLAMA_PREBUILT_DIR=$root" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+            "LLAMA_PREBUILT_SHARED=0" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+            Write-Host "[ok] LLAMA_PREBUILT_DIR=$root"
+          } catch {
+            Write-Host "[warn] prebuilt llama artifact unavailable or invalid; fallback to source build"
+          }
 
       # ── Standalone LLVM 19 for bindgen ──────────────────────────────────────
       # VS2022's bundled Clang 19 is an MSVC-compat build (clang-cl) whose
@@ -568,12 +757,44 @@ jobs:
           LLVM_CONFIG:   ${{ env.LLVM_CONFIG }}
           CC:            ${{ env.CC }}
           CXX:           ${{ env.CXX }}
-          RUSTC_WRAPPER: sccache
-        run: >
-          cargo clippy -p skill
-          --target x86_64-pc-windows-msvc
-          --features llm-vulkan,screenshots
-          -- -D warnings
+        run: |
+          set -euo pipefail
+          run_cmd() {
+            cargo clippy -p skill \
+              --target x86_64-pc-windows-msvc \
+              --features llm-vulkan,screenshots \
+              -- -D warnings
+          }
+          if ! run_cmd; then
+            if [[ -n "${LLAMA_PREBUILT_DIR:-}" ]]; then
+              echo "::warning::windows clippy failed with prebuilt llama; retrying with source build"
+              unset LLAMA_PREBUILT_DIR LLAMA_PREBUILT_SHARED
+              run_cmd
+            else
+              exit 1
+            fi
+          fi
+
+      - name: Capture + summarize sccache hit rate (Windows job)
+        if: always()
+        shell: bash
+        run: |
+          mkdir -p ci-metrics
+          sccache --show-stats > ci-metrics/windows-sccache-stats.txt || true
+          STATS=ci-metrics/windows-sccache-stats.txt
+          if [[ ! -f "$STATS" ]]; then
+            echo "- sccache stats: unavailable" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          TOTAL_HIT_RATE="$(awk '/^Cache hits rate[[:space:]]/{print $(NF-1)" "$NF; exit}' "$STATS")"
+          RUST_HIT_RATE="$(awk '/^Cache hits rate \(Rust\)/{print $(NF-1)" "$NF; exit}' "$STATS")"
+          CACHE_LOCATION="$(awk -F'Cache location[[:space:]]+' '/^Cache location/{print $2; exit}' "$STATS")"
+          {
+            echo "## sccache metrics (Windows job)"
+            echo "- Cache location: ${CACHE_LOCATION:-unknown}"
+            echo "- Total hit rate: ${TOTAL_HIT_RATE:-unknown}"
+            echo "- Rust hit rate: ${RUST_HIT_RATE:-unknown}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   # ── LLM end-to-end integration test ──────────────────────────────────────────
   llm-e2e:
@@ -601,6 +822,7 @@ jobs:
         uses: Swatinem/rust-cache@v2.9.0
         with:
           workspaces: ". -> src-tauri/target"
+          shared-key: linux-ci-x86_64-unknown-linux-gnu-v1
           save-if: false
           cache-targets: false
           cache-on-failure: false
@@ -707,6 +929,7 @@ jobs:
         uses: Swatinem/rust-cache@v2.9.0
         with:
           workspaces: ". -> src-tauri/target"
+          shared-key: linux-ci-x86_64-unknown-linux-gnu-v1
           save-if: false
           cache-targets: false
           cache-on-failure: false

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -100,6 +100,7 @@ jobs:
         uses: Swatinem/rust-cache@v2.9.0
         with:
           workspaces: ". -> src-tauri/target"
+          shared-key: linux-release-x86_64-unknown-linux-gnu-v1
           cache-targets: false
           cache-on-failure: false
 
@@ -143,6 +144,51 @@ jobs:
       # Cached and installed via reusable setup action.
       - name: Setup Vulkan SDK
         uses: ./.github/actions/setup-vulkan-linux
+
+      - name: Download prebuilt llama libs (Linux, optional)
+        shell: bash
+        run: |
+          set -euo pipefail
+          URL="https://github.com/eugenehp/llama-cpp-rs/releases/latest/download/llama-prebuilt-linux-x86_64-unknown-linux-gnu-q1-vulkan.tar.gz"
+          ARCHIVE="$RUNNER_TEMP/llama-prebuilt-linux.tar.gz"
+          DEST="$RUNNER_TEMP/llama-prebuilt-linux"
+          EXPECTED_TARGET="x86_64-unknown-linux-gnu"
+          EXPECTED_FEATURE="vulkan"
+          mkdir -p "$DEST"
+
+          if ! curl -fL "$URL" -o "$ARCHIVE"; then
+            echo "[warn] prebuilt llama artifact unavailable; fallback to source build"
+            exit 0
+          fi
+
+          tar -xzf "$ARCHIVE" -C "$DEST"
+          ROOT="$DEST"
+          if [[ ! -d "$ROOT/lib" && ! -d "$ROOT/lib64" && ! -d "$ROOT/bin" ]]; then
+            ROOT="$(find "$DEST" -mindepth 1 -maxdepth 1 -type d | head -n1 || true)"
+          fi
+
+          if [[ -z "${ROOT:-}" ]]; then
+            echo "[warn] prebuilt llama archive layout invalid; fallback to source build"
+            exit 0
+          fi
+
+          if ! find "$ROOT" -type f \( -name '*.a' -o -name '*.so' \) | head -n1 >/dev/null; then
+            echo "[warn] prebuilt llama archive contains no static/shared libs; fallback to source build"
+            exit 0
+          fi
+
+          if [[ -f "$ROOT/metadata.json" ]]; then
+            TARGET="$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1])).get("target",""))' "$ROOT/metadata.json")"
+            FEATURES="$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1])).get("features",""))' "$ROOT/metadata.json")"
+            if [[ "$TARGET" != "$EXPECTED_TARGET" || "$FEATURES" != *"$EXPECTED_FEATURE"* ]]; then
+              echo "[warn] prebuilt metadata mismatch (target=$TARGET features=$FEATURES); fallback to source build"
+              exit 0
+            fi
+          fi
+
+          echo "LLAMA_PREBUILT_DIR=$ROOT" >> "$GITHUB_ENV"
+          echo "LLAMA_PREBUILT_SHARED=0" >> "$GITHUB_ENV"
+          echo "[ok] LLAMA_PREBUILT_DIR=$ROOT"
 
       # ── espeak-ng static library ──────────────────────────────────────────────
       # ── Build frontend ────────────────────────────────────────────────────────
@@ -190,7 +236,18 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          cargo build -p skill --release --locked --target x86_64-unknown-linux-gnu --features custom-protocol,llm-vulkan,screenshots --timings
+          run_cmd() {
+            cargo build -p skill --release --locked --target x86_64-unknown-linux-gnu --features custom-protocol,llm-vulkan,screenshots --timings
+          }
+          if ! run_cmd; then
+            if [[ -n "${LLAMA_PREBUILT_DIR:-}" ]]; then
+              echo "::warning::Linux release compile failed with prebuilt llama; retrying with source build"
+              unset LLAMA_PREBUILT_DIR LLAMA_PREBUILT_SHARED
+              run_cmd
+            else
+              exit 1
+            fi
+          fi
 
       # ── Upload cargo build timings ─────────────────────────────────────────
       # The --timings flag produces an HTML report showing per-crate compile

--- a/.github/workflows/release-mac.yml
+++ b/.github/workflows/release-mac.yml
@@ -81,6 +81,51 @@ jobs:
       - name: Install protoc (macOS)
         run: brew install protobuf
 
+      - name: Download prebuilt llama libs (macOS, optional)
+        shell: bash
+        run: |
+          set -euo pipefail
+          URL="https://github.com/eugenehp/llama-cpp-rs/releases/latest/download/llama-prebuilt-macos-aarch64-apple-darwin-q1-metal.tar.gz"
+          ARCHIVE="$RUNNER_TEMP/llama-prebuilt-macos.tar.gz"
+          DEST="$RUNNER_TEMP/llama-prebuilt-macos"
+          EXPECTED_TARGET="aarch64-apple-darwin"
+          EXPECTED_FEATURE="metal"
+          mkdir -p "$DEST"
+
+          if ! curl -fL "$URL" -o "$ARCHIVE"; then
+            echo "[warn] prebuilt llama artifact unavailable; fallback to source build"
+            exit 0
+          fi
+
+          tar -xzf "$ARCHIVE" -C "$DEST"
+          ROOT="$DEST"
+          if [[ ! -d "$ROOT/lib" && ! -d "$ROOT/lib64" && ! -d "$ROOT/bin" ]]; then
+            ROOT="$(find "$DEST" -mindepth 1 -maxdepth 1 -type d | head -n1 || true)"
+          fi
+
+          if [[ -z "${ROOT:-}" ]]; then
+            echo "[warn] prebuilt llama archive layout invalid; fallback to source build"
+            exit 0
+          fi
+
+          if ! find "$ROOT" -type f \( -name '*.a' -o -name '*.dylib' \) | head -n1 >/dev/null; then
+            echo "[warn] prebuilt llama archive contains no static/shared libs; fallback to source build"
+            exit 0
+          fi
+
+          if [[ -f "$ROOT/metadata.json" ]]; then
+            TARGET="$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1])).get("target",""))' "$ROOT/metadata.json")"
+            FEATURES="$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1])).get("features",""))' "$ROOT/metadata.json")"
+            if [[ "$TARGET" != "$EXPECTED_TARGET" || "$FEATURES" != *"$EXPECTED_FEATURE"* ]]; then
+              echo "[warn] prebuilt metadata mismatch (target=$TARGET features=$FEATURES); fallback to source build"
+              exit 0
+            fi
+          fi
+
+          echo "LLAMA_PREBUILT_DIR=$ROOT" >> "$GITHUB_ENV"
+          echo "LLAMA_PREBUILT_SHARED=0" >> "$GITHUB_ENV"
+          echo "[ok] LLAMA_PREBUILT_DIR=$ROOT"
+
       # ── Pre-flight: verify every secret is set ───────────────────────────────
       # Catches missing / renamed secrets in seconds instead of after a 15-minute
       # build.  Each variable is checked for non-empty; none of the values are
@@ -207,6 +252,7 @@ jobs:
       # CLI (`npx tauri build`) injects this feature automatically, but we
       # bypass the CLI here to avoid its post-compilation SIGILL.
       - name: Compile (frontend + Rust)
+        shell: bash
         env:
           RUSTC_WRAPPER: sccache
           # Let sccache cache C/C++ compilations from cmake-based -sys crates
@@ -216,9 +262,21 @@ jobs:
           CMAKE_C_COMPILER_LAUNCHER:   sccache
           CMAKE_CXX_COMPILER_LAUNCHER: sccache
         run: |
+          set -euo pipefail
           npm run build
           npm run -s verify:tauri:frontend
-          cargo build -p skill --release --locked --target aarch64-apple-darwin --features custom-protocol,llm-metal --timings
+          run_cmd() {
+            cargo build -p skill --release --locked --target aarch64-apple-darwin --features custom-protocol,llm-metal --timings
+          }
+          if ! run_cmd; then
+            if [[ -n "${LLAMA_PREBUILT_DIR:-}" ]]; then
+              echo "::warning::macOS release compile failed with prebuilt llama; retrying with source build"
+              unset LLAMA_PREBUILT_DIR LLAMA_PREBUILT_SHARED
+              run_cmd
+            else
+              exit 1
+            fi
+          fi
 
       # ── Upload cargo build timings ─────────────────────────────────────────
       # The --timings flag produces an HTML report showing per-crate compile

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -350,6 +350,53 @@ jobs:
           $nsisDir | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           Write-Host "[ok] NSIS_DIR=$nsisDir"
 
+      - name: Download prebuilt llama libs (Windows, optional)
+        shell: powershell
+        run: |
+          $url = "https://github.com/eugenehp/llama-cpp-rs/releases/latest/download/llama-prebuilt-windows-x86_64-pc-windows-msvc-q1-vulkan.tar.gz"
+          $archive = Join-Path $env:RUNNER_TEMP "llama-prebuilt-windows.tar.gz"
+          $dest = Join-Path $env:RUNNER_TEMP "llama-prebuilt-windows"
+          $expectedTarget = "x86_64-pc-windows-msvc"
+          $expectedFeature = "vulkan"
+          New-Item -ItemType Directory -Force -Path $dest | Out-Null
+
+          try {
+            Invoke-WebRequest -Uri $url -OutFile $archive
+            tar -xzf $archive -C $dest
+
+            $root = $dest
+            if (-not (Test-Path (Join-Path $root "lib")) -and -not (Test-Path (Join-Path $root "lib64")) -and -not (Test-Path (Join-Path $root "bin"))) {
+              $candidate = Get-ChildItem $dest -Directory | Select-Object -First 1
+              if ($candidate) { $root = $candidate.FullName }
+            }
+
+            if (-not $root -or -not (Test-Path $root)) {
+              Write-Host "[warn] prebuilt llama archive layout invalid; fallback to source build"
+              exit 0
+            }
+
+            $libs = Get-ChildItem -Path $root -Recurse -File -Include *.lib,*.dll -ErrorAction SilentlyContinue | Select-Object -First 1
+            if (-not $libs) {
+              Write-Host "[warn] prebuilt llama archive contains no windows libs; fallback to source build"
+              exit 0
+            }
+
+            $metadataPath = Join-Path $root "metadata.json"
+            if (Test-Path $metadataPath) {
+              $meta = Get-Content $metadataPath -Raw | ConvertFrom-Json
+              if ($meta.target -ne $expectedTarget -or -not ($meta.features -like "*$expectedFeature*")) {
+                Write-Host "[warn] prebuilt metadata mismatch (target=$($meta.target) features=$($meta.features)); fallback to source build"
+                exit 0
+              }
+            }
+
+            "LLAMA_PREBUILT_DIR=$root" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+            "LLAMA_PREBUILT_SHARED=0" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+            Write-Host "[ok] LLAMA_PREBUILT_DIR=$root"
+          } catch {
+            Write-Host "[warn] prebuilt llama artifact unavailable or invalid; fallback to source build"
+          }
+
       # ── Ensure VC++ Redistributable DLLs are available ───────────────────────
       # The binary uses dynamic CRT (/MD).  The NSIS installer bundles the CRT
       # DLLs app-locally alongside skill.exe.  This step ensures they exist on
@@ -589,7 +636,20 @@ jobs:
           fi
           sccache --show-stats || true
 
-          cargo build -p skill --release --locked --features custom-protocol,llm-vulkan,screenshots --timings
+          run_cmd() {
+            cargo build -p skill --release --locked --features custom-protocol,llm-vulkan,screenshots --timings
+          }
+
+          if ! run_cmd; then
+            if [[ -n "${LLAMA_PREBUILT_DIR:-}" ]]; then
+              echo "::warning::Windows release compile failed with prebuilt llama; retrying with source build"
+              unset LLAMA_PREBUILT_DIR LLAMA_PREBUILT_SHARED
+              run_cmd
+            else
+              exit 1
+            fi
+          fi
+
           sccache --show-stats || true
 
       # Make sure NSIS packaging can always find onnxruntime.dll next to the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -227,7 +227,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2112,7 +2112,7 @@ checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width 0.2.0",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -2148,7 +2148,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3589,7 +3589,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3632,7 +3632,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
- "libloading 0.8.9",
+ "libloading 0.7.4",
 ]
 
 [[package]]
@@ -4118,7 +4118,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5097,7 +5097,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
+ "windows-link 0.1.3",
  "windows-result 0.4.1",
 ]
 
@@ -6729,7 +6729,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7311,9 +7311,9 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "llama-cpp-4"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "803f294071b0190f86d94f79a4467870455c824817f54aa23e1b427d0b0fe7f7"
+checksum = "c37455bab4e063dfc3477af575ffda77f7f1c986027ce030c2e3cb7ffc280452"
 dependencies = [
  "enumflags2",
  "llama-cpp-sys-4",
@@ -7323,9 +7323,9 @@ dependencies = [
 
 [[package]]
 name = "llama-cpp-sys-4"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cb2934292b2f2bdbb60052fa14ee3d8cb70a587e3616e385b3294bb06ef6a50"
+checksum = "9806ae8d09895a05b0c12c44501bdf2daed1b9628adf12147c9a84cd8c37853f"
 dependencies = [
  "bindgen 0.72.1",
  "cc",
@@ -8424,7 +8424,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11284,7 +11284,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11352,7 +11352,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11599,7 +11599,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12694,7 +12694,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -13761,7 +13761,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -14734,7 +14734,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -15797,7 +15797,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -16455,7 +16455,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/skill-llm/Cargo.toml
+++ b/crates/skill-llm/Cargo.toml
@@ -32,13 +32,13 @@ hf-hub     = "0.5"
 skill-tools  = { path = "../skill-tools", default-features = false }
 skill-skills = { path = "../skill-skills" }
 
-llama-cpp-4 = { version = "0.2.23", optional = true, features = ["q1"] }
+llama-cpp-4 = { version = "0.2.24", optional = true, features = ["q1"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-llama-cpp-4 = { version = "0.2.23", optional = true, features = ["q1", "metal"] }
+llama-cpp-4 = { version = "0.2.24", optional = true, features = ["q1", "metal"] }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-llama-cpp-4 = { version = "0.2.23", optional = true, features = ["q1", "vulkan"] }
+llama-cpp-4 = { version = "0.2.24", optional = true, features = ["q1", "vulkan"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -249,7 +249,7 @@ async-stream      = "0.3"
 # neutts 0.1.0 uses llama-cpp-4 so there is no longer
 # a `links = "llama"` conflict when both `tts-neutts` and `llm` are enabled.
 # Cargo deduplicates both into a single llama-cpp-4 package.
-llama-cpp-4 = { version = "0.2.23", optional = true, features = ["q1"] }
+llama-cpp-4 = { version = "0.2.24", optional = true, features = ["q1"] }
 
 # mDNS / Bonjour service discovery
 mdns-sd = "0.18"
@@ -359,7 +359,7 @@ ort = { version = "=2.0.0-rc.11", default-features = false, features = ["coreml"
 # llama-cpp-4 with Metal GPU offload — merged with the base [dependencies] entry
 # so that when the `llm` feature is active the Metal backend is compiled in
 # automatically on macOS.
-llama-cpp-4 = { version = "0.2.23", optional = true, features = ["q1", "metal"] }
+llama-cpp-4 = { version = "0.2.24", optional = true, features = ["q1", "metal"] }
 # Pure-Rust Focus Mode / Do Not Disturb control — no Swift, no ObjC, no
 # private frameworks.  Replaces the hand-rolled Assertions.json writer.
 macos-focus = "0.0.1"
@@ -386,7 +386,7 @@ ort = { version = "=2.0.0-rc.11", default-features = false, features = ["downloa
 # llama-cpp-4 with Vulkan GPU offload — merged with the base [dependencies]
 # entry so that when the `llm` feature is active the Vulkan backend is compiled
 # in automatically on Linux and Windows.
-llama-cpp-4 = { version = "0.2.23", optional = true, features = ["q1", "vulkan"] }
+llama-cpp-4 = { version = "0.2.24", optional = true, features = ["q1", "vulkan"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/src/lifecycle.rs
+++ b/src-tauri/src/lifecycle.rs
@@ -473,9 +473,19 @@ pub(crate) fn start_iroh_remote_session(app: &AppHandle, peer_id: String) {
         s.session_start_utc = Some(unix_secs());
         s.snr_sum = 0.0;
         s.snr_count = 0;
+
+        // Remote iroh sessions are source-driven by incoming tunnel data.
+        // Disable BLE-style auto-reconnect loops so pending retry tasks from
+        // a previously preferred local device (e.g. AttentivU) stop
+        // immediately and don't race with iroh session startup.
+        s.pending_reconnect = false;
+        s.retry_attempt = 0;
+
         s.status
             .reset_for_scanning("iroh-remote", &csv, Some(&peer_id));
         s.status.device_id = Some(peer_id.clone());
+        s.status.retry_attempt = 0;
+        s.status.retry_countdown_secs = 0;
 
         // Look up the registered client name for this peer so the dashboard
         // can display it (e.g. "Mario's iPhone").

--- a/src-tauri/src/session_runner.rs
+++ b/src-tauri/src/session_runner.rs
@@ -114,6 +114,17 @@ pub(crate) async fn run_device_session(
         Some(DATA_WATCHDOG_TIMEOUT)
     };
 
+    // iroh-remote sessions are source-driven by the phone tunnel and should
+    // not enter BLE-style auto-reconnect loops on desktop disconnect.
+    if kind == "iroh-remote" {
+        let r = app.app_state();
+        let mut s = r.lock_or_recover();
+        s.pending_reconnect = false;
+        s.retry_attempt = 0;
+        s.status.retry_attempt = 0;
+        s.status.retry_countdown_secs = 0;
+    }
+
     let mut user_cancelled = false;
     let mut last_event_at = Instant::now();
     loop {
@@ -296,7 +307,7 @@ pub(crate) async fn run_device_session(
 
     // ── Finalise ─────────────────────────────────────────────────────────────
     if let Some(ref mut c) = csv {
-        finalize_session(&app, c, &csv_path, user_cancelled);
+        finalize_session(&app, c, &csv_path, user_cancelled, kind);
     } else {
         // CSV was never opened (disconnect before first EEG frame, or
         // adapter never emitted Eeg events).  Still need to clean up
@@ -1337,6 +1348,7 @@ fn finalize_session(
     csv: &mut SessionWriter,
     csv_path: &Path,
     user_cancelled: bool,
+    kind: &str,
 ) {
     csv.flush();
     write_session_meta(app, csv_path);
@@ -1345,7 +1357,10 @@ fn finalize_session(
         let r = app.app_state();
         let mut s = r.lock_or_recover();
         if s.status.sample_count > 0 {
-            s.pending_reconnect = true;
+            // iroh-remote reconnects are phone-driven (watcher starts a new
+            // session when remote events arrive). Enabling desktop
+            // auto-reconnect here causes wrong routing (e.g. as attentivu).
+            s.pending_reconnect = kind != "iroh-remote";
         }
     }
     let error_msg = if user_cancelled {


### PR DESCRIPTION
## Summary
- use prebuilt llama-cpp-rs artifacts in CI/release (Linux + Windows)
- validate artifact layout + metadata before enabling prebuilt mode
- keep safe fallback to local source build when prebuilt is missing/invalid
- add retry logic: if prebuilt build path fails, unset prebuilt env and rebuild from source
- bump llama crates to 0.2.24 to consume fixed artifact packaging

## Validation
- CI run on this branch succeeded: https://github.com/NeuroSkill-com/skill/actions/runs/23923819150
- Previous comparable main run: https://github.com/NeuroSkill-com/skill/actions/runs/23922147797

### Timing
- Total pipeline: **25.2m -> 18.85m**
- Rust job: **24.97m -> 18.65m**
- Windows job: **20.78m -> 16.38m**

## Fallback behavior
- if artifact download fails, metadata mismatches, or libs missing -> continue with source build
- if prebuilt path causes cargo failure -> retry automatically with source build
