### PR TITLE
Fix: add Git `usr/bin` to PATH on Windows so `patch` is found during build 

### DIFF
--- a/scripts/tauri-build.js
+++ b/scripts/tauri-build.js
@@ -220,6 +220,17 @@ if (isMingwTarget) {
     platformFlags = [...platformFlags, "--no-bundle"];
   }
 } else if (isWin) {
+  // ── Windows: ensure Git Unix tools (patch, etc.) are on PATH ───────────────
+  //
+  // llama-cpp-sys applies .patch files during its build script.  The `patch`
+  // utility ships with Git for Windows at Git\usr\bin\patch.exe but is not
+  // added to PATH by default.  Inject it here so Cargo child processes can
+  // find it without requiring a manual PATH change.
+  const gitUsrBin = "C:\\Program Files\\Git\\usr\\bin";
+  if (existsSync(gitUsrBin) && !(process.env.PATH || "").includes(gitUsrBin)) {
+    process.env.PATH = `${gitUsrBin};${process.env.PATH || ""}`;
+  }
+
   execSync("powershell -NoProfile -ExecutionPolicy Bypass -File scripts\\install-vulkan-sdk.ps1", {
     cwd: root,
     stdio: "inherit",


### PR DESCRIPTION
**Description:**
`llama-cpp-sys` applies `.patch` files in its Cargo build script by shelling out to the `patch` binary. On Windows, this binary ships with Git for Windows at `Git\usr\bin\patch.exe`, but that directory is **not** added to `PATH` by the default Git installer — only `Git\cmd\` is (which contains `git.exe` itself). As a result, the build script panics with `program not found` even on machines that have Git installed. macOS is unaffected because `patch` is a standard OS utility always present in `/usr/bin`. 

## Fix
 In `scripts/tauri-build.js`, prepend `C:\Program Files\Git\usr\bin` to `process.env.PATH` at the start of the Windows setup block. Since `execSync` inherits `process.env`, all Cargo child processes — including the `llama-cpp-sys` build script — can find `patch.exe` without requiring users to manually modify their system PATH. The injection is guarded: it only runs if the directory exists on disk and isn't already present in `PATH`.
 
Build error:
<img width="594" height="232" alt="Screenshot 2026-04-03 200044" src="https://github.com/user-attachments/assets/3c88d700-46dd-45db-a45f-d27748097741" />
